### PR TITLE
Improve caps detection

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: BadWordBlocker
 main: surva\badwordblocker\BadWordBlocker
-version: 1.0.3
+version: 1.0.4
 api: 3.0.0-ALPHA7
 commands:
   chat:

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -12,6 +12,11 @@ badwords: "fuck,shit"
 # Time between chat messages
 waitingtime: 03
 
+# Percentage of uppercase chars in a message required to trigger caps checker
+uppercasepercentage: 0.75
+# Minimum amount of chars in a message required to activate caps checker (to avoid blocking HI,OK,etc.)
+minimumchars: 3
+
 # Messages
 blockmessage: "§eYour message has been §cblocked §eby BadWordBlocker."
 lastwritten: "§cPlease write something else"

--- a/src/surva/badwordblocker/BadWordBlocker.php
+++ b/src/surva/badwordblocker/BadWordBlocker.php
@@ -61,6 +61,17 @@ class BadWordBlocker extends PluginBase {
     }
 
     /**
+     * Counts uppercase chars in a string
+     *
+     * @param $string
+     * @return int
+     */
+	public function countUppercaseChars(string $string): int{
+		preg_match_all("/[A-Z]/", $string, $matches);
+		return count($matches[0]);
+	}
+
+    /**
      * @return array
      */
     public function getList(): array {

--- a/src/surva/badwordblocker/EventListener.php
+++ b/src/surva/badwordblocker/EventListener.php
@@ -51,7 +51,10 @@ class EventListener implements Listener {
             }
         }
 
-        if(ctype_upper($message)) {
+        if(
+			($this->getBadWordBlocker()->countUppercaseChars($message) / strlen($message)) >= $this->getBadWordBlocker()->getConfig()->get("uppercasepercentage")
+			&& strlen($message) >= $this->getBadWordBlocker()->getConfig()->get("minimumchars")
+		){
             $player->sendMessage($this->getBadWordBlocker()->getConfig()->get("caps"));
             $event->setCancelled(true);
 


### PR DESCRIPTION
This PR improves the CAPS detection.
It uses the percentage of CAPS used in the message to determine whether caps where used or not. This percentage is 75% by default.
Also if the message is only 1 or 2 chars long it doesn’t check the percentage (to allow for “OK” for example) this can also be adjusted or can be set to 0 to be disabled.