### PR TITLE
Add block list import from web feature

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -7,7 +7,16 @@ author: survanetwork
 description: A chat filter which can block certain things
 website: https://plugins.surva.net/#badwordblocker
 
+commands:
+  badwordblocker:
+    description: "BadWordBlocker plugin main command"
+    usage: "/badwordblocker <action>"
+    permission: badwordblocker.manage
+    aliases: ["bwb"]
 permissions:
+  badwordblocker.manage:
+    description: "Manage settings/administrative actions of the BadWordBlocker plugin"
+    default: op
   badwordblocker.bypass:
     description: "Bypass the chat filters of BadWordBlocker"
     default: op

--- a/resources/languages/en.yml
+++ b/resources/languages/en.yml
@@ -28,7 +28,7 @@ import:
       dropdown: "Select a list"
     confirm:
       title: "Confirm list import"
-      description: "The list \"{name}\" will be imported."
+      description: "The list \"{name}\" will be imported. §6This will overwrite all existing words added to the config file."
       license: "It is licensed under the {license} license. The sources for this list are available at {credits_url}."
   success: "§aList §f{name} §awas imported successfully."
   error_code:

--- a/resources/languages/en.yml
+++ b/resources/languages/en.yml
@@ -18,3 +18,19 @@ blocked:
 punishment:
   kick: "§eYou've been §ckicked §eby BadWordBlocker."
   ban: "§eYou've been §cbanned §eby BadWordBlocker."
+
+# Import workflow
+import:
+  form:
+    select:
+      title: "Select list to import"
+      description: "You can select from some ready-to-use profanity lists from the internet published under an open license to import."
+      dropdown: "Select a list"
+    confirm:
+      title: "Confirm list import"
+      description: "The list \"{name}\" will be imported."
+      license: "It is licensed under the {license} license. The sources for this list are available at {credits_url}."
+  success: "§aList §f{name} §awas imported successfully."
+  error_code:
+    web_request: "§cCould not import list from the internet data source, connection failed!"
+    config_save: "§cCouldn't save config file with imported list!"

--- a/resources/list_sources.yml
+++ b/resources/list_sources.yml
@@ -1,0 +1,11 @@
+sources:
+  - name: "dsojevic/profanity-list"
+    source_url: "https://raw.githubusercontent.com/dsojevic/profanity-list/main/en.txt"
+    format: "text"
+    license: "MIT"
+    credits_url: "https://github.com/dsojevic/profanity-list"
+  - name: "chucknorris-io/swear-words"
+    source_url: "https://raw.githubusercontent.com/chucknorris-io/swear-words/master/en"
+    format: "text"
+    license: "CC-BY-4.0"
+    credits_url: "https://github.com/chucknorris-io/swear-words"

--- a/src/surva/badwordblocker/form/ImportConfirmForm.php
+++ b/src/surva/badwordblocker/form/ImportConfirmForm.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * BadWordBlocker | form for confirming list import
+ */
+
+namespace surva\badwordblocker\form;
+
+use JsonException;
+use pocketmine\form\Form;
+use pocketmine\player\Player;
+use pocketmine\utils\InternetException;
+use surva\badwordblocker\BadWordBlocker;
+use surva\badwordblocker\util\Import;
+use surva\badwordblocker\util\Messages;
+
+class ImportConfirmForm implements Form
+{
+    private BadWordBlocker $badWordBlocker;
+
+    /**
+     * @var array properties of the selected list source
+     */
+    private array $selectedListSource;
+
+    private string $type = "custom_form";
+    private string $title;
+    private array $content;
+
+    /**
+     * @param  \surva\badwordblocker\BadWordBlocker  $badWordBlocker
+     * @param  \surva\badwordblocker\util\Messages  $messages
+     * @param  array  $selectedListSource
+     */
+    public function __construct(BadWordBlocker $badWordBlocker, Messages $messages, array $selectedListSource)
+    {
+        $this->badWordBlocker = $badWordBlocker;
+        $this->selectedListSource = $selectedListSource;
+
+        $this->title = $messages->getMessage("import.form.confirm.title");
+        $this->content = [
+          [
+            "type" => "label",
+            "text" => $messages->getMessage("import.form.confirm.description", ["name" => $selectedListSource["name"]])
+          ],
+          [
+            "type" => "label",
+            "text" => $messages->getMessage(
+                "import.form.confirm.license",
+                [
+                    "license" => $selectedListSource["license"],
+                    "credits_url" => $selectedListSource["credits_url"]
+                ]
+            )
+          ],
+        ];
+    }
+
+    /**
+     * Handle form submit
+     *
+     * @param  \pocketmine\player\Player  $player
+     * @param $data
+     *
+     * @return void
+     */
+    public function handleResponse(Player $player, $data): void
+    {
+        if (!is_array($data)) {
+            return;
+        }
+
+        try {
+            $arr = Import::textListAsArray($this->selectedListSource["source_url"]);
+        } catch (InternetException $e) {
+            $this->badWordBlocker->sendMessage($player, "import.error_code.web_request");
+
+            return;
+        }
+        try {
+            Import::importArrayToConfig($this->badWordBlocker->getConfig(), $arr);
+        } catch (JsonException $e) {
+            $this->badWordBlocker->sendMessage($player, "import.error_code.config_save");
+
+            return;
+        }
+        $this->badWordBlocker->loadConfig();
+
+        $this->badWordBlocker->sendMessage($player, "import.success", ["name" => $this->selectedListSource["name"]]);
+    }
+
+    /**
+     * Return JSON data of the form
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+          "type"    => $this->type,
+          "title"   => $this->title,
+          "content" => $this->content,
+        ];
+    }
+}

--- a/src/surva/badwordblocker/form/ImportSelectForm.php
+++ b/src/surva/badwordblocker/form/ImportSelectForm.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * BadWordBlocker | form for selecting list to import
+ */
+
+namespace surva\badwordblocker\form;
+
+use pocketmine\form\Form;
+use pocketmine\player\Player;
+use surva\badwordblocker\BadWordBlocker;
+use surva\badwordblocker\util\Messages;
+
+class ImportSelectForm implements Form
+{
+    private BadWordBlocker $badWordBlocker;
+    private Messages $messages;
+
+    /**
+     * @var array properties of available list sources
+     */
+    private array $listSources;
+
+    private string $type = "custom_form";
+    private string $title;
+    private array $content;
+
+    /**
+     * @param  \surva\badwordblocker\BadWordBlocker  $badWordBlocker
+     * @param  \surva\badwordblocker\util\Messages  $messages
+     * @param  array  $listSources
+     */
+    public function __construct(BadWordBlocker $badWordBlocker, Messages $messages, array $listSources)
+    {
+        $this->badWordBlocker = $badWordBlocker;
+        $this->messages = $messages;
+        $this->listSources = $listSources;
+
+        $this->title = $messages->getMessage("import.form.select.title");
+        $this->content = [
+          [
+            "type" => "label",
+            "text" => $messages->getMessage("import.form.select.description")
+          ],
+          [
+            "type"    => "dropdown",
+            "text"    => $messages->getMessage("import.form.select.dropdown"),
+            "options" => array_map(function ($listSource) {
+                return $listSource["name"];
+            }, $listSources)
+          ]
+        ];
+    }
+
+    /**
+     * Handle form submit
+     *
+     * @param  \pocketmine\player\Player  $player
+     * @param $data
+     *
+     * @return void
+     */
+    public function handleResponse(Player $player, $data): void
+    {
+        if (!is_array($data)) {
+            return;
+        }
+
+        if (count($data) < 2) {
+            return;
+        }
+
+        $selectedListI = $data[1];
+
+        if (!isset($this->listSources[$selectedListI])) {
+            return;
+        }
+
+        $selectedList = $this->listSources[$selectedListI];
+        $player->sendForm(new ImportConfirmForm($this->badWordBlocker, $this->messages, $selectedList));
+    }
+
+    /**
+     * Return JSON data of the form
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+          "type"    => $this->type,
+          "title"   => $this->title,
+          "content" => $this->content,
+        ];
+    }
+}

--- a/src/surva/badwordblocker/util/Import.php
+++ b/src/surva/badwordblocker/util/Import.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * BadWordBlocker | utility for importing lists to config
+ */
+
+namespace surva\badwordblocker\util;
+
+use pocketmine\utils\Config;
+use pocketmine\utils\Internet;
+use pocketmine\utils\InternetException;
+
+class Import
+{
+    private const HTTP_OK = 200;
+
+    /**
+     * Get a simple plain text list from the internet as an array
+     *
+     * @param  string  $sourceUrl
+     *
+     * @return array
+     */
+    public static function textListAsArray(string $sourceUrl): array
+    {
+        $webRes = Internet::getURL($sourceUrl);
+
+        if ($webRes->getCode() !== self::HTTP_OK) {
+            throw new InternetException();
+        }
+
+        $text = $webRes->getBody();
+        return explode(PHP_EOL, $text);
+    }
+
+    /**
+     * Import array of blocked words to config
+     *
+     * @param  \pocketmine\utils\Config  $config
+     * @param  array  $list
+     *
+     * @return void
+     * @throws \JsonException
+     */
+    public static function importArrayToConfig(Config $config, array $list): void
+    {
+        $config->set("badwords", $list);
+        $config->save();
+    }
+}


### PR DESCRIPTION
### 📋 What's this pull request about?

Add a feature to easily import profanity word list with an open license from the web using a GUI form to provide a fast way to make the plugin ready to use. There are two form windows, the first to choose the list source to import and a second to confirm its license and overwriting the config.

### 🔧 Is this pull request related to an issue?

#23
