### PR TITLE
Refactor filters to be its own class managed by one FilterManager

### DIFF
--- a/src/surva/badwordblocker/BadWordBlocker.php
+++ b/src/surva/badwordblocker/BadWordBlocker.php
@@ -6,15 +6,13 @@
 
 namespace surva\badwordblocker;
 
-use DateInterval;
-use DateTime;
 use DirectoryIterator;
-use Exception;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\player\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\utils\Config;
+use surva\badwordblocker\filter\FilterManager;
 use surva\badwordblocker\form\ImportSelectForm;
 use surva\badwordblocker\util\Messages;
 
@@ -31,19 +29,14 @@ class BadWordBlocker extends PluginBase
     private array $translationMessages;
 
     /**
+     * @var \surva\badwordblocker\filter\FilterManager class for managing registered filters and check messages
+     */
+    private FilterManager $filterManager;
+
+    /**
      * @var array available sources for lists to import
      */
     private array $availableListSources;
-
-    /**
-     * @var array players to which the bypassed message was already sent during this runtime
-     */
-    private array $bypassedMessageSent;
-
-    private array $blockedWords;
-    private array $playersTimeWritten;
-    private array $playersLastWritten;
-    private array $playersViolations;
 
     /**
      * Plugin has been enabled, initial setup
@@ -55,15 +48,10 @@ class BadWordBlocker extends PluginBase
         $this->defaultMessages = new Config($this->getFile() . "resources/languages/en.yml");
         $this->loadLanguageFiles();
 
+        $this->filterManager = new FilterManager($this);
+
         $listSourcesConfig = new Config($this->getFile() . "resources/list_sources.yml");
         $this->availableListSources = $listSourcesConfig->getNested("sources");
-
-        $this->loadConfig();
-
-        $this->bypassedMessageSent = [];
-        $this->playersTimeWritten = [];
-        $this->playersLastWritten = [];
-        $this->playersViolations  = [];
 
         $this->getServer()->getPluginManager()->registerEvents(new EventListener($this), $this);
     }
@@ -96,217 +84,6 @@ class BadWordBlocker extends PluginBase
         }
 
         return false;
-    }
-
-    /**
-     * Check the message of a player on the different aspects (true = alright; false = found something)
-     *
-     * @param  \pocketmine\player\Player  $player
-     * @param  string  $message
-     *
-     * @return bool
-     */
-    public function checkMessage(Player $player, string $message): bool
-    {
-        $playerName = $player->getName();
-
-        if ($this->getConfig()->get("ignorespaces", true) === true) {
-            $message = str_replace(" ", "", $message);
-        }
-
-        $translMessages = new Messages($this, $player);
-
-        if (($blocked = $this->contains($message, $this->blockedWords)) !== null) {
-            if ($player->hasPermission("badwordblocker.bypass.swear")) {
-                $this->sendBypassedMessage($player);
-
-                return true;
-            }
-
-            if ($this->getConfig()->get("showblocked", false) === true) {
-                $player->sendMessage(
-                    $translMessages->getMessage("blocked.messagewithblocked", ["blocked" => $blocked])
-                );
-            } else {
-                $player->sendMessage($translMessages->getMessage("blocked.message"));
-            }
-
-            $this->handleViolation($player);
-
-            return false;
-        }
-
-        if (isset($this->playersLastWritten[$playerName])) {
-            if ($this->playersLastWritten[$playerName] === $message) {
-                if ($player->hasPermission("badwordblocker.bypass.same")) {
-                    $this->sendBypassedMessage($player);
-
-                    return true;
-                }
-
-                $player->sendMessage($translMessages->getMessage("blocked.lastwritten"));
-                $this->handleViolation($player);
-
-                return false;
-            }
-        }
-
-        if (isset($this->playersTimeWritten[$playerName])) {
-            if ($this->playersTimeWritten[$playerName] > new DateTime()) {
-                if ($player->hasPermission("badwordblocker.bypass.spam")) {
-                    $this->sendBypassedMessage($player);
-
-                    return true;
-                }
-
-                $player->sendMessage($translMessages->getMessage("blocked.timewritten"));
-                $this->handleViolation($player);
-
-                return false;
-            }
-        }
-
-        $uppercasePercentage = $this->getConfig()->get("uppercasepercentage", 0.75);
-        $minimumChars        = $this->getConfig()->get("minimumchars", 3);
-
-        $messageLength = strlen($message);
-
-        if (
-                $messageLength > $minimumChars and ($this->countUppercaseChars(
-                    $message
-                ) / $messageLength) >= $uppercasePercentage
-        ) {
-            if ($player->hasPermission("badwordblocker.bypass.caps")) {
-                $this->sendBypassedMessage($player);
-
-                return true;
-            }
-
-            $player->sendMessage($translMessages->getMessage("blocked.caps"));
-            $this->handleViolation($player);
-
-            return false;
-        }
-
-        try {
-            $this->playersTimeWritten[$playerName] = new DateTime();
-            $this->playersTimeWritten[$playerName] = $this->playersTimeWritten[$playerName]->add(
-                new DateInterval("PT" . $this->getConfig()->get("waitingtime", 2) . "S")
-            );
-            $this->playersLastWritten[$playerName] = $message;
-        } catch (Exception $exception) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Handle the occurrence of a chat block event, e.g. kick or ban the player if configured
-     *
-     * @param  \pocketmine\player\Player  $player
-     */
-    private function handleViolation(Player $player): void
-    {
-        $playerName = $player->getName();
-
-        if (!isset($this->playersViolations[$playerName])) {
-            $this->playersViolations[$playerName] = 0;
-        }
-
-        $this->playersViolations[$playerName]++;
-
-        $violKick       = $this->getConfig()->getNested("violations.kick", 0);
-        $violBan        = $this->getConfig()->getNested("violations.ban", 0);
-        $resetAfterKick = $this->getConfig()->getNested("violations.resetafterkick", true);
-
-        $translMessages = new Messages($this, $player);
-
-        if ($this->playersViolations[$playerName] === $violKick) {
-            $player->kick($translMessages->getMessage("punishment.kick"));
-
-            if ($resetAfterKick) {
-                $this->playersViolations[$playerName] = 0;
-            }
-        } elseif ($this->playersViolations[$playerName] === $violBan) {
-            $this->getServer()->getNameBans()->addBan($playerName, $translMessages->getMessage("punishment.ban"));
-            $player->kick($translMessages->getMessage("punishment.ban"));
-
-            $this->playersViolations[$playerName] = 0;
-        }
-    }
-
-    /**
-     * Send filter bypassed reminder to a player if not already sent during this session
-     *
-     * @param  \pocketmine\player\Player  $pl
-     *
-     * @return void
-     */
-    private function sendBypassedMessage(Player $pl): void
-    {
-        if ($this->getConfig()->get("send_bypassed_message", true) !== true) {
-            return;
-        }
-
-        $id = $pl->getId();
-
-        if (isset($this->bypassedMessageSent[$id])) {
-            return;
-        }
-
-        $this->sendMessage($pl, "filter_bypassed");
-        $this->bypassedMessageSent[$id] = true;
-    }
-
-    /**
-     * Check if a string contains a specific string from an array and return it
-     *
-     * @param  string  $string
-     * @param  array  $contains
-     *
-     * @return string|null
-     */
-    private function contains(string $string, array $contains): ?string
-    {
-        $ignoreSpaces = $this->getConfig()->get("ignorespaces", true) === true;
-
-        foreach ($contains as $contain) {
-            if (
-                str_contains(
-                    strtolower($string),
-                    $ignoreSpaces ? str_replace(" ", "", $contain) : $contain
-                )
-            ) {
-                return $contain;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Counts uppercase chars in a string
-     *
-     * @param  string  $string
-     *
-     * @return int
-     */
-    private function countUppercaseChars(string $string): int
-    {
-        preg_match_all("/[A-Z]/", $string, $matches);
-
-        return count($matches[0]);
-    }
-
-    /**
-     * Load bad word list from config file
-     *
-     * @return void
-     */
-    public function loadConfig(): void
-    {
-        $this->blockedWords = $this->getConfig()->get("badwords", ["fuck", "shit", "bitch"]);
     }
 
     /**
@@ -355,6 +132,14 @@ class BadWordBlocker extends PluginBase
                 $this->getFile() . "resources/languages/" . $langId . ".yml"
             );
         }
+    }
+
+    /**
+     * @return \surva\badwordblocker\filter\FilterManager
+     */
+    public function getFilterManager(): FilterManager
+    {
+        return $this->filterManager;
     }
 
     /**

--- a/src/surva/badwordblocker/EventListener.php
+++ b/src/surva/badwordblocker/EventListener.php
@@ -58,7 +58,7 @@ class EventListener implements Listener
 
         $realMessage = implode(" ", $args);
 
-        if (!$this->badWordBlocker->checkMessage($sender, $realMessage)) {
+        if ($this->badWordBlocker->getFilterManager()->checkMessage($sender, $realMessage)) {
             $event->cancel();
         }
     }
@@ -73,7 +73,7 @@ class EventListener implements Listener
         $player  = $event->getPlayer();
         $message = $event->getMessage();
 
-        if (!$this->badWordBlocker->checkMessage($player, $message)) {
+        if ($this->badWordBlocker->getFilterManager()->checkMessage($player, $message)) {
             $event->cancel();
         }
     }

--- a/src/surva/badwordblocker/filter/CapsLockFilter.php
+++ b/src/surva/badwordblocker/filter/CapsLockFilter.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * BadWordBlocker | caps lock (all uppercase) filter
+ */
+
+namespace surva\badwordblocker\filter;
+
+use pocketmine\player\Player;
+use surva\badwordblocker\util\Messages;
+
+class CapsLockFilter extends Filter
+{
+    private FilterManager $filterManager;
+
+    /**
+     * @param  \surva\badwordblocker\filter\FilterManager  $filterManager
+     */
+    public function __construct(FilterManager $filterManager)
+    {
+        $this->filterManager = $filterManager;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function check(Player $pl, string $message): bool
+    {
+        $uppercasePercentage = $this->filterManager->getBadWordBlocker()->getConfig()->get("uppercasepercentage", 0.75);
+        $minimumChars        = $this->filterManager->getBadWordBlocker()->getConfig()->get("minimumchars", 3);
+
+        $messageLength = strlen($message);
+
+        return $messageLength > $minimumChars and ($this->countUppercaseChars(
+            $message
+        ) / $messageLength) >= $uppercasePercentage;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function action(Player $pl, string $originalMessage): void
+    {
+        $messages = new Messages($this->filterManager->getBadWordBlocker(), $pl);
+
+        $pl->sendMessage($messages->getMessage("blocked.caps"));
+        $this->filterManager->handleViolation($pl);
+    }
+
+    /**
+     * Counts uppercase chars in a string
+     *
+     * @param  string  $string
+     *
+     * @return int
+     */
+    private function countUppercaseChars(string $string): int
+    {
+        preg_match_all("/[A-Z]/", $string, $matches);
+
+        return count($matches[0]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBypassPermission(): string
+    {
+        return "badwordblocker.bypass.caps";
+    }
+}

--- a/src/surva/badwordblocker/filter/DuplicateFilter.php
+++ b/src/surva/badwordblocker/filter/DuplicateFilter.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * BadWordBlocker | duplicate message filter
+ */
+
+namespace surva\badwordblocker\filter;
+
+use pocketmine\player\Player;
+use surva\badwordblocker\util\Messages;
+
+class DuplicateFilter extends Filter
+{
+    private FilterManager $filterManager;
+    private array $playersLastWritten;
+
+    /**
+     * @param  \surva\badwordblocker\filter\FilterManager  $filterManager
+     */
+    public function __construct(FilterManager $filterManager)
+    {
+        $this->filterManager = $filterManager;
+        $this->playersLastWritten = [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function check(Player $pl, string $message): bool
+    {
+        $plName = $pl->getName();
+
+        return isset($this->playersLastWritten[$plName]) && $this->playersLastWritten[$plName] === $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function action(Player $pl, string $originalMessage): void
+    {
+        $messages = new Messages($this->filterManager->getBadWordBlocker(), $pl);
+
+        $pl->sendMessage($messages->getMessage("blocked.lastwritten"));
+        $this->filterManager->handleViolation($pl);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function saveMessage(Player $pl, string $message): void
+    {
+        $this->playersLastWritten[$pl->getName()] = $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBypassPermission(): string
+    {
+        return "badwordblocker.bypass.same";
+    }
+}

--- a/src/surva/badwordblocker/filter/Filter.php
+++ b/src/surva/badwordblocker/filter/Filter.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * BadWordBlocker | general filter class
+ */
+
+namespace surva\badwordblocker\filter;
+
+use pocketmine\player\Player;
+
+abstract class Filter
+{
+    /**
+     * Check message if it violates the filter
+     *
+     * @param  \pocketmine\player\Player  $pl
+     * @param  string  $message
+     *
+     * @return bool true = violation found; false = message ok, no violation
+     */
+    abstract public function check(Player $pl, string $message): bool;
+
+    /**
+     * Handle violation of the filter
+     *
+     * @param  \pocketmine\player\Player  $pl
+     * @param  string  $originalMessage
+     *
+     * @return void
+     */
+    abstract public function action(Player $pl, string $originalMessage): void;
+
+    /**
+     * Save the message for comparing on next check (e.g. for duplicate, time, etc.)
+     *
+     * @param  \pocketmine\player\Player  $pl
+     * @param  string  $message
+     *
+     * @return void
+     */
+    public function saveMessage(Player $pl, string $message): void
+    {
+        // empty by default
+    }
+
+    /**
+     * Reload config files used for filtering
+     *
+     * @return void
+     */
+    public function reloadConfig(): void
+    {
+        // empty by default
+    }
+
+    /**
+     * Permission name to bypass the filter
+     *
+     * @return string
+     */
+    abstract public function getBypassPermission(): string;
+}

--- a/src/surva/badwordblocker/filter/FilterManager.php
+++ b/src/surva/badwordblocker/filter/FilterManager.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * BadWordBlocker | manages/registers filters, check messages using all filters, etc.
+ */
+
+namespace surva\badwordblocker\filter;
+
+use pocketmine\player\Player;
+use surva\badwordblocker\BadWordBlocker;
+use surva\badwordblocker\util\Messages;
+
+class FilterManager
+{
+    private BadWordBlocker $badWordBlocker;
+
+    /**
+     * @var \surva\badwordblocker\filter\Filter[] filters to check against
+     */
+    private array $filters;
+
+    /**
+     * @var array players to which the bypassed message was already sent during this runtime
+     */
+    private array $bypassedMessageSent;
+
+    private array $playersViolations;
+
+    /**
+     * @param  \surva\badwordblocker\BadWordBlocker  $badWordBlocker
+     */
+    public function __construct(BadWordBlocker $badWordBlocker)
+    {
+        $this->badWordBlocker = $badWordBlocker;
+
+        $this->bypassedMessageSent = [];
+        $this->playersViolations  = [];
+
+        $this->registerFilters();
+    }
+
+    /**
+     * Check the message of a player using registered filters
+     * (true = violation found; false = message ok, no violation)
+     *
+     * @param  \pocketmine\player\Player  $player
+     * @param  string  $message
+     *
+     * @return bool
+     */
+    public function checkMessage(Player $player, string $message): bool
+    {
+        if ($this->badWordBlocker->getConfig()->get("ignorespaces", true) === true) {
+            $message = str_replace(" ", "", $message);
+        }
+
+        foreach ($this->filters as $filter) {
+            $checkResult = $filter->check($player, $message);
+            $filter->saveMessage($player, $message);
+
+            if ($checkResult) {
+                if ($player->hasPermission($filter->getBypassPermission())) {
+                    $this->sendBypassedMessage($player);
+                } else {
+                    $filter->action($player, $message);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Handle the occurrence of a chat block event, e.g. kick or ban the player if configured
+     *
+     * @param  \pocketmine\player\Player  $player
+     */
+    public function handleViolation(Player $player): void
+    {
+        $playerName = $player->getName();
+
+        if (!isset($this->playersViolations[$playerName])) {
+            $this->playersViolations[$playerName] = 0;
+        }
+
+        $this->playersViolations[$playerName]++;
+
+        $violKick       = $this->badWordBlocker->getConfig()->getNested("violations.kick", 0);
+        $violBan        = $this->badWordBlocker->getConfig()->getNested("violations.ban", 0);
+        $resetAfterKick = $this->badWordBlocker->getConfig()->getNested("violations.resetafterkick", true);
+
+        $translMessages = new Messages($this->badWordBlocker, $player);
+
+        if ($this->playersViolations[$playerName] === $violKick) {
+            $player->kick($translMessages->getMessage("punishment.kick"));
+
+            if ($resetAfterKick) {
+                $this->playersViolations[$playerName] = 0;
+            }
+        } elseif ($this->playersViolations[$playerName] === $violBan) {
+            $this->badWordBlocker->getServer()->getNameBans()->addBan(
+                $playerName,
+                $translMessages->getMessage("punishment.ban")
+            );
+            $player->kick($translMessages->getMessage("punishment.ban"));
+
+            $this->playersViolations[$playerName] = 0;
+        }
+    }
+
+    /**
+     * Send filter bypassed reminder to a player if not already sent during this session
+     *
+     * @param  \pocketmine\player\Player  $pl
+     *
+     * @return void
+     */
+    private function sendBypassedMessage(Player $pl): void
+    {
+        if ($this->badWordBlocker->getConfig()->get("send_bypassed_message", true) !== true) {
+            return;
+        }
+
+        $id = $pl->getId();
+
+        if (isset($this->bypassedMessageSent[$id])) {
+            return;
+        }
+
+        $this->badWordBlocker->sendMessage($pl, "filter_bypassed");
+        $this->bypassedMessageSent[$id] = true;
+    }
+
+    /**
+     * Register filters to check the message against
+     *
+     * @return void
+     */
+    public function registerFilters(): void
+    {
+        $this->filters = [
+          new SwearWordFilter($this),
+          new DuplicateFilter($this),
+          new SpeedFilter($this),
+          new CapsLockFilter($this)
+        ];
+    }
+
+    /**
+     * Tell filters to reload their config files
+     *
+     * @return void
+     */
+    public function reloadFilterConfigs(): void
+    {
+        foreach ($this->filters as $filter) {
+            $filter->reloadConfig();
+        }
+    }
+
+    /**
+     * @return \surva\badwordblocker\BadWordBlocker
+     */
+    public function getBadWordBlocker(): BadWordBlocker
+    {
+        return $this->badWordBlocker;
+    }
+}

--- a/src/surva/badwordblocker/filter/SpeedFilter.php
+++ b/src/surva/badwordblocker/filter/SpeedFilter.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * BadWordBlocker | writing speed (spam) filter
+ */
+
+namespace surva\badwordblocker\filter;
+
+use DateInterval;
+use DateTime;
+use Exception;
+use pocketmine\player\Player;
+use surva\badwordblocker\util\Messages;
+
+class SpeedFilter extends Filter
+{
+    private FilterManager $filterManager;
+    private array $playersTimeWritten;
+
+    /**
+     * @param  \surva\badwordblocker\filter\FilterManager  $filterManager
+     */
+    public function __construct(FilterManager $filterManager)
+    {
+        $this->filterManager = $filterManager;
+        $this->playersTimeWritten = [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function check(Player $pl, string $message): bool
+    {
+        $plName = $pl->getName();
+
+        return isset($this->playersTimeWritten[$plName]) && $this->playersTimeWritten[$plName] > new DateTime();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function action(Player $pl, string $originalMessage): void
+    {
+        $messages = new Messages($this->filterManager->getBadWordBlocker(), $pl);
+
+        $pl->sendMessage($messages->getMessage("blocked.timewritten"));
+        $this->filterManager->handleViolation($pl);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function saveMessage(Player $pl, string $message): void
+    {
+        $plName = $pl->getName();
+
+        try {
+            $this->playersTimeWritten[$plName] = new DateTime();
+            $this->playersTimeWritten[$plName] = $this->playersTimeWritten[$plName]->add(
+                new DateInterval(
+                    "PT" . $this->filterManager->getBadWordBlocker()->getConfig()->get(
+                        "waitingtime",
+                        2
+                    ) . "S"
+                )
+            );
+        } catch (Exception $e) {
+            // do nothing
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBypassPermission(): string
+    {
+        return "badwordblocker.bypass.spam";
+    }
+}

--- a/src/surva/badwordblocker/filter/SwearWordFilter.php
+++ b/src/surva/badwordblocker/filter/SwearWordFilter.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * BadWordBlocker | swear word filter
+ */
+
+namespace surva\badwordblocker\filter;
+
+use pocketmine\player\Player;
+use surva\badwordblocker\util\Messages;
+
+class SwearWordFilter extends Filter
+{
+    private FilterManager $filterManager;
+    private array $blockedWords;
+
+    /**
+     * @param  \surva\badwordblocker\filter\FilterManager  $filterManager
+     */
+    public function __construct(FilterManager $filterManager)
+    {
+        $this->filterManager = $filterManager;
+
+        $this->loadConfig();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function check(Player $pl, string $message): bool
+    {
+        return $this->contains($message, $this->blockedWords) !== null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function action(Player $pl, string $originalMessage): void
+    {
+        $messages = new Messages($this->filterManager->getBadWordBlocker(), $pl);
+
+        if ($this->filterManager->getBadWordBlocker()->getConfig()->get("showblocked") === true) {
+            $blocked = $this->contains($originalMessage, $this->blockedWords);
+
+            $pl->sendMessage(
+                $messages->getMessage("blocked.messagewithblocked", ["blocked" => $blocked])
+            );
+        } else {
+            $pl->sendMessage($messages->getMessage("blocked.message"));
+        }
+
+        $this->filterManager->handleViolation($pl);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reloadConfig(): void
+    {
+        $this->loadConfig();
+    }
+
+    /**
+     * Check if a string contains a specific string from an array and return it
+     *
+     * @param  string  $string
+     * @param  array  $contains
+     *
+     * @return string|null
+     */
+    private function contains(string $string, array $contains): ?string
+    {
+        $ignoreSpaces = $this->filterManager->getBadWordBlocker()->getConfig()->get("ignorespaces", true) === true;
+
+        foreach ($contains as $contain) {
+            if (
+                str_contains(
+                    strtolower($string),
+                    $ignoreSpaces ? str_replace(" ", "", $contain) : $contain
+                )
+            ) {
+                return $contain;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Load bad word list from config file
+     *
+     * @return void
+     */
+    public function loadConfig(): void
+    {
+        $this->blockedWords = $this->filterManager->getBadWordBlocker()->getConfig()->get(
+            "badwords",
+            ["fuck", "shit", "bitch"]
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBypassPermission(): string
+    {
+        return "badwordblocker.bypass.swear";
+    }
+}

--- a/src/surva/badwordblocker/form/ImportConfirmForm.php
+++ b/src/surva/badwordblocker/form/ImportConfirmForm.php
@@ -84,7 +84,7 @@ class ImportConfirmForm implements Form
 
             return;
         }
-        $this->badWordBlocker->loadConfig();
+        $this->badWordBlocker->getFilterManager()->reloadFilterConfigs();
 
         $this->badWordBlocker->sendMessage($player, "import.success", ["name" => $this->selectedListSource["name"]]);
     }


### PR DESCRIPTION
### 📋 What's this pull request about?

To make the code cleaner, each filter is now placed in its own class following an abstract class and checks are done by a FilterManager checking each filter class.

### 🔧 Is this pull request related to an issue?

\-
